### PR TITLE
Cimas sync 2026-07-05: propagate #300 gaps + accumulated template drift

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  pull-requests: write
+  contents: write
   pages: write
   id-token: write
 
@@ -24,28 +25,23 @@ jobs:
       image: metanorma/metanorma:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
-      - name: Bundler install
-        uses: metanorma/ci/docker-gem-install@main
-
       - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@v2
+        id: build-and-publish
+        uses: actions-mn/build-and-publish@main
         with:
-          destination: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
           agree-to-terms: true
-          use-bundler: true
+          destination: artifact
 
   deploy:
-    if: ${{ github.ref_name == github.event.repository.default_branch }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions-mn/deploy-pages@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cimas-sync wave 2026-07-05 propagating template changes accumulated over the past ~2 weeks to the cimas-managed repos.

## What this wave carries

- **Master `.rubocop.yml` enrichment** ([`metanorma/ci#334`](https://github.com/metanorma/ci/pull/334)) — adds `plugins: rubocop-rspec, rubocop-performance, rubocop-rake`; bumps `TargetRubyVersion: 3.4 → 3.3` to align with the org minimum per [`ci#274`](https://github.com/metanorma/ci/issues/274).
- **Rubygems-release workflow refinements** ([`ci#325`](https://github.com/metanorma/ci/pull/325), [`#326`](https://github.com/metanorma/ci/pull/326), [`#327`](https://github.com/metanorma/ci/pull/327), [`#328`](https://github.com/metanorma/ci/pull/328), [`#324`](https://github.com/metanorma/ci/pull/324)) — post-publish gem verification, post-dispatch acknowledgement poll, release-chain.md documentation of "dispatch accepted vs acted on", skip dev/test bundle install groups, patches regex relaxation.
- **Gap 1** ([`metanorma/cimas#55`](https://github.com/metanorma/cimas/pull/55), [`ci#344`](https://github.com/metanorma/ci/pull/344), [`#345`](https://github.com/metanorma/ci/pull/345)) — `metanorma` migrates to `master/rake.yml.erb` with `with: private-fonts: true`; `metanorma-standoc` and `isodoc` also migrate (byte-identical output).
- **Gap 2** ([`ci#346`](https://github.com/metanorma/ci/pull/346)) — `pubid` monorepo re-added, migrates from its local `.github/workflows/generic-rake.yml` fork to consume the new shared `metanorma/ci/.github/workflows/monorepo-per-gem-rake.yml` reusable.
- **Assorted workflow template updates** — permissions blocks, description-text refinements, template-forward drift accumulated over June.

## Why this wave now

The [scheduled cimas-drift-audit](https://github.com/metanorma/ci/blob/main/.github/workflows/cimas-drift-audit.yml) first-run report on 2026-07-04 surfaced 242 accumulated silent-drift warnings across the 157 cimas-managed repos. This wave clears the ~90% of them that were pure accumulated template drift.

## Flatten-stale mode

This wave uses `cimas open-prs --flatten-stale` (per the newly-shipped [`cimas#56`](https://github.com/metanorma/cimas/pull/56)), so prior open `cimas-sync-*` PRs on each repo are **auto-closed as superseded** rather than left to stack. The wave-regeneration invariant holds — every cimas-sync regenerates the same file set from cimas.yml — so newer waves strictly supersede older by construction.

If any prior wave PR carried hand-edited content that should be preserved, rebase your local changes onto this branch before merging.

## Merge posture

- The diffs are template-refresh only; no behavioural changes to your gem's build/release path.
- Merge freely once the CI checks pass.
- If the CI check fails or a diff looks unexpected, ping @opoudjis on this PR and we'll investigate.

## Related

- [`metanorma/ci#300`](https://github.com/metanorma/ci/issues/300) — cimas revival design gaps (Gap 1, 2, 3, 4 now all closed).
- [`metanorma/ci#342`](https://github.com/metanorma/ci/issues/342) — rolling drift-audit tracking issue (will show the drop after this wave lands).

🤖
